### PR TITLE
Added operator overloading

### DIFF
--- a/docs/day-04/operators-in-cpp.md
+++ b/docs/day-04/operators-in-cpp.md
@@ -279,6 +279,7 @@ Operator overloading allows you to redefine the way operators work for user-defi
 Overloading an operator does not change:
 - the operator precedence,
 - the associativity of the operator,
+- the arity of the operator, or
 - the meaning of how the operator works on objects of
 built-in types.
 
@@ -303,7 +304,7 @@ public:
     Complex(double r = 0, double i = 0) : real(r), imag(i) {}
 
     // Overload the + operator
-    Complex operator+ (const Complex& obj) {
+    Complex operator+ (Complex& obj) {
         return Complex(real + obj.real, imag + obj.imag);
     }
 };
@@ -324,7 +325,7 @@ public:
 
 Operators that **cannot** be overloaded include: `::`, `.*`, `.`, `? :`, `sizeof`
 
-Example:
+### Example:
 ```cpp
 #include <iostream>
 
@@ -350,3 +351,12 @@ int main() {
     return 0;
 }
 ```
+
+### Operator Overloading Rules
+
+When overloading operators, there are several rules to keep in mind:
+
+1. **Preserve the Operator's Original Meaning**: The overloaded operator should make sense in the context of the operation it performs.
+2. **Return Types**: The return type should be appropriate for the operation. For example, `operator+` should return a new object, while `operator+=` should return a reference to `*this`.
+3. **Symmetry**: Ensure symmetric behavior where applicable. For example, `a == b` should return the same result as `b == a`.
+4. **Do Not Overload Operators Irrelevantly**: Only overload operators that make sense for your class. For example, overloading the arithmetic operators for a class that represents a complex number makes sense, but overloading them for a class that represents a database connection does not.

--- a/docs/day-04/operators-in-cpp.md
+++ b/docs/day-04/operators-in-cpp.md
@@ -276,6 +276,12 @@ int main() {
 
 Operator overloading allows you to redefine the way operators work for user-defined types (classes and structs). It enables you to specify more intuitive ways to perform operations on objects of your classes.
 
+Overloading an operator does not change:
+- the operator precedence,
+- the associativity of the operator,
+- the meaning of how the operator works on objects of
+built-in types.
+
 ### Syntax
 An overloaded operator is implemented as a special member function with the keyword `operator` followed by the symbol of the operator being overloaded.
 
@@ -316,7 +322,7 @@ public:
 - Member access operators: `->`, `.` (only for pointers to members)
 - Input and output operators: `>>`, `<<`
 
-Operators that **cannot** be overloaded include: `::`, `.*`, `.`, `? :`
+Operators that **cannot** be overloaded include: `::`, `.*`, `.`, `? :`, `sizeof`
 
 Example:
 ```cpp

--- a/docs/day-04/operators-in-cpp.md
+++ b/docs/day-04/operators-in-cpp.md
@@ -270,3 +270,77 @@ int main() {
     return 0;
 }
 ```
+## 4. Operator Overloading
+
+### Introduction 
+
+Operator overloading allows you to redefine the way operators work for user-defined types (classes and structs). It enables you to specify more intuitive ways to perform operations on objects of your classes.
+
+### Syntax
+An overloaded operator is implemented as a special member function with the keyword `operator` followed by the symbol of the operator being overloaded.
+
+```cpp
+class ClassName {
+public:
+    ReturnType operatorOpSymbol (ParameterList) {
+        // Function body
+    }
+};
+```
+
+### Example
+```cpp
+class Complex {
+public:
+    double real, imag;
+
+    Complex(double r = 0, double i = 0) : real(r), imag(i) {}
+
+    // Overload the + operator
+    Complex operator+ (const Complex& obj) {
+        return Complex(real + obj.real, imag + obj.imag);
+    }
+};
+```
+
+### Types of Operators that Can Be Overloaded
+
+- Arithmetic operators: `+`, `-`, `*`, `/`, `%`
+- Relational operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical operators: `&&`, `||`, `!`
+- Bitwise operators: `&`, `|`, `^`, `~`, `<<`, `>>`
+- Increment and decrement operators: `++`, `--`
+- Assignment operators: `=`, `+=`, `-=`, `*=`, `/=`, `%=`
+- Subscript operator: `[]`
+- Function call operator: `()`
+- Member access operators: `->`, `.` (only for pointers to members)
+- Input and output operators: `>>`, `<<`
+
+Operators that **cannot** be overloaded include: `::`, `.*`, `.`, `? :`
+
+Example:
+```cpp
+#include <iostream>
+
+class Complex {
+public:
+    double real, imag;
+
+    Complex(double r = 0, double i = 0) : real(r), imag(i) {}
+
+    // Overload the == operator
+    bool operator== (const Complex& obj) const {
+        return (real == obj.real && imag == obj.imag);
+    }
+};
+
+int main() {
+    Complex c1(3.0, 4.0), c2(3.0, 4.0);
+    if (c1 == c2) {
+        std::cout << "c1 and c2 are equal" << std::endl;
+    } else {
+        std::cout << "c1 and c2 are not equal" << std::endl;
+    }
+    return 0;
+}
+```


### PR DESCRIPTION
Fix #99

I have uploaded content for operator overloading:
- Added fundamental theory
- Examples for better understanding
- Rules and pointers for the concept
- Reviewed the content added

![Screenshot 2024-06-07 002601](https://github.com/subhadipbhowmik/30-Days-Of-CPP/assets/138357063/d3776297-a9e5-4350-993f-e8b4ecade5e3)
![Screenshot 2024-06-07 002613](https://github.com/subhadipbhowmik/30-Days-Of-CPP/assets/138357063/64caa913-936a-4424-9fe6-cb7bf340f027)
![Screenshot 2024-06-07 002625](https://github.com/subhadipbhowmik/30-Days-Of-CPP/assets/138357063/3fb6948e-bfba-41ea-8b8c-86bbbd635cc0)


If you permit, I shall create a separate day as Overloading under which I can add this part.
