### PR TITLE
Chatbot Color blue added to solve overlap of colors

### DIFF
--- a/src/components/Chatbot/style.css
+++ b/src/components/Chatbot/style.css
@@ -225,7 +225,7 @@ body{
   
   .bpw-widget-btn{
     border-radius: 50%;
-    background:#00bfa6;
+    background:blue;
   }
   
   .bpw-floating-button::before {


### PR DESCRIPTION
issue no #414

I have added blue color to chatbot button.
So color is not overlap now.

Before
![image](https://github.com/subhadipbhowmik/30-Days-Of-CPP/assets/126322584/8531d12d-de88-4164-b42d-fe0b3ca2f416)

After
![image](https://github.com/subhadipbhowmik/30-Days-Of-CPP/assets/126322584/66334b78-a971-459f-a864-f86e5bc83656)

